### PR TITLE
Debug/fix setProps

### DIFF
--- a/examples/ssr/src/components/CrudButton.ts
+++ b/examples/ssr/src/components/CrudButton.ts
@@ -2,13 +2,13 @@ import { fics } from 'ficsjs'
 import Button from '@/components/materials/Button'
 import type { Method } from '@/types'
 
-export default () =>
-  fics<{}, { method: Method; click: (method: Method) => void }>({
-    name: 'crud-button',
+export default (suffix = '') =>
+  fics<{}, { method: Method; click: (method: Method) => void; isDisabled: boolean }>({
+    name: `crud-button${suffix}`,
     children: [Button()],
     props: {
       descendant: ({ children: { button } }) => button,
-      values: ({ props: { method, click } }) => ({ text: method, click: () => click(method) })
+      values: ({ props: { method, click, isDisabled } }) => ({ text: method, click: () => click(method), isDisabled })
     },
     html: ({ children: { button }, template }) => template`${button}`
   })

--- a/examples/ssr/src/components/Users.ts
+++ b/examples/ssr/src/components/Users.ts
@@ -6,75 +6,103 @@ import type { Method, User } from '@/types'
 
 const headers: HeadersInit = { 'Content-type': 'application/json; charset=UTF-8' }
 
+const crudButtonPut = CrudButton('-put')
+const crudButtonPatch = CrudButton('-patch')
+const crudButtonDelete = CrudButton('-delete')
+
 export default () =>
   fics({
     name: 'users',
-    children: [CrudButton()],
+    children: [crudButtonPut, crudButtonPatch, crudButtonDelete],
     data: () => ({ users, userId: NaN, methods: ['PUT', 'PATCH', 'DELETE'] as Method[] }),
     props: [
       {
-        descendant: ({ children: { crudButton }, getChildren }) => getChildren(crudButton).button,
+        descendant: ({ children: { crudButtonPut }, getChildren }) => getChildren(crudButtonPut).button,
         values: () => ({ isDisabled: ({ getData }) => isNaN(getData('userId')) })
       },
       {
-        descendant: ({ children: { crudButton } }) => crudButton,
+        descendant: ({ children: { crudButtonPut } }) => crudButtonPut,
         values: ({ setData, crud }) => ({
-          click:
-            ({ getData }) =>
-            async (method: Method) => {
-              const userId = getData('userId')
-              const options = { method, ...headers }
-
-              if (method === 'DELETE') {
-                await crud<User>(`${api}/${userId}`, options)
-                setData(
-                  'users',
-                  getData('users').filter(({ id }) => id !== userId)
-                )
-              } else {
-                const name = prompt('Please enter a new user name.')
-                if (name) {
-                  await crud<User>(`${api}/${userId}`, {
-                    ...options,
-                    body: JSON.stringify({ id: userId, name })
-                  })
-                  setData(
-                    'users',
-                    getData('users').map(user => (user.id === userId ? { ...user, name } : user))
-                  )
-                }
-              }
-
-              setData('userId', NaN)
+          method: 'PUT',
+          click: ({ getData }) => async () => {
+            const userId = getData('userId')
+            const name = prompt('Please enter a new user name.')
+            if (name) {
+              await crud<User>(`${api}/${userId}`, {
+                method: 'PUT',
+                ...headers,
+                body: JSON.stringify({ id: userId, name })
+              })
+              setData('users', getData('users').map(user => (user.id === userId ? { ...user, name } : user)))
             }
+            setData('userId', NaN)
+          }
+        })
+      },
+      {
+        descendant: ({ children: { crudButtonPatch }, getChildren }) => getChildren(crudButtonPatch).button,
+        values: () => ({ isDisabled: ({ getData }) => isNaN(getData('userId')) })
+      },
+      {
+        descendant: ({ children: { crudButtonPatch } }) => crudButtonPatch,
+        values: ({ setData, crud }) => ({
+          method: 'PATCH',
+          click: ({ getData }) => async () => {
+            const userId = getData('userId')
+            const name = prompt('Please enter a new user name.')
+            if (name) {
+              await crud<User>(`${api}/${userId}`, {
+                method: 'PATCH',
+                ...headers,
+                body: JSON.stringify({ id: userId, name })
+              })
+              setData('users', getData('users').map(user => (user.id === userId ? { ...user, name } : user)))
+            }
+            setData('userId', NaN)
+          }
+        })
+      },
+      {
+        descendant: ({ children: { crudButtonDelete }, getChildren }) => getChildren(crudButtonDelete).button,
+        values: () => ({ isDisabled: ({ getData }) => isNaN(getData('userId')) })
+      },
+      {
+        descendant: ({ children: { crudButtonDelete } }) => crudButtonDelete,
+        values: ({ setData, crud }) => ({
+          method: 'DELETE',
+          click: ({ getData }) => async () => {
+            const userId = getData('userId')
+            await crud<User>(`${api}/${userId}`, { method: 'DELETE', ...headers })
+            setData('users', getData('users').filter(({ id }) => id !== userId))
+            setData('userId', NaN)
+          }
         })
       }
     ],
     html: ({
-      children: { crudButton },
-      data: { users, userId, methods },
-      template,
-      setProps
+      children: { crudButtonPut, crudButtonPatch, crudButtonDelete },
+      data: { users, userId },
+      template
     }) => template`
-      <div class="buttons mb-7 gap-4">${methods.map(method => setProps(crudButton, { method }))}</div>
+      <div class="buttons mb-7 gap-4">${crudButtonPut}${crudButtonPatch}${crudButtonDelete}</div>
       <div class="space-y-4">
         ${users.map(user => {
-          const { id } = user
-          const keys: (keyof User)[] = ['id', 'name', 'email']
+      const { id } = user
+      const keys: (keyof User)[] = ['id', 'name', 'email']
 
-          return template`
+      return template`
             <div class="clickable w-3xs space-y-2 mx-auto" key="${id}" tabindex="0">
               ${keys.map((key, index) => {
-                const _key = keys[index]
-                return template`
+        const _key = keys[index]
+        return template`
                   <p class="text-base ${userId === id ? 'text-red' : 'text-white'}" key="${id}-${key}">
                     ${_key.charAt(0).toUpperCase() + _key.slice(1)}: ${user[key]}
                   </p>
                 `
-              })}
+      })}
             </div>
           `
-        })}
+    })}
       </div>
     `,
     css: {


### PR DESCRIPTION
## 問題点
  - setProps 関数でコンポーネントを複製する際、複製されたインスタンスと元のインスタンスで props の伝播が断絶する
  - userId 変更時に Button の isDisabled が画面上で反映されない
  - 再レンダリングのたびに新しいインスタンスが作成され、DOM 上で f-crud-button-7, -8 のようにサフィックスが増加する

## 対応方針
  1. setProps でインスタンス複製しても、元の props 変化が複製後のインスタンスに伝わるようにする
  2. setProps を使わずに親から子に個別の props を渡す **← 今回はこちらを採択**

## 主な変更点

### As-Is
```
  // 1つの CrudButton インスタンス + setProps で複製
  children: [CrudButton()],
  html: ({ setProps }) => template`
    <div>${methods.map(method => setProps(crudButton, { method }))}</div>
```

### To-Be
```
  // 3つの独立した CrudButton インスタンス
  const crudButtonPut = CrudButton('-put')
  const crudButtonPatch = CrudButton('-patch')
  const crudButtonDelete = CrudButton('-delete')

  children: [crudButtonPut, crudButtonPatch, crudButtonDelete],
  html: ({ children }) => template`
    <div>${crudButtonPut}${crudButtonPatch}${crudButtonDelete}</div>
```

## 不具合の原因と対応

### 原因

  1. setProps が毎回新しいインスタンスを作成する
  2. クローンされたインスタンスは元の props 更新を受け取らない
  3. レンダリングのたびに setProps が実行され、インスタンス番号が増加する

### 対応

  1. setProps を完全削除し、動的クローンを排除した
  2. 独立したインスタンスを作成し、各メソッドごとに専用の CrudButton を事前に作成するようにした
  3. props で各インスタンスに直接 method, click, isDisabled を設定した

### 結果

  - インスタンス番号が f-crud-button-put, -patch, -delete で固定された
  - props 動的更新により userId 変更時に isDisabled が正常に反映されるようになった
  - setProps による複製問題を回避し、同一インスタンスでの props 更新を実現した

## 動作確認

![FiCsJS-with-Hono-Google-Chrome-2025-06-19-17-27-47](https://github.com/user-attachments/assets/b306a85e-04dd-4285-b0ea-50937661e4c4)